### PR TITLE
inital 0.2.16

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,6 +35,11 @@ about:
   license_family: Apache
   license_file: LICENSE
   summary: C99 implementation of huffman encoding/decoding
+  description: |
+    This is a cross-platform C99 implementation of compression algorithms such as gzip, and huffman 
+    encoding/decoding. Currently only huffman is implemented.
+  doc_url: https://github.com/awslabs/aws-c-compression
+  dev_url: https://github.com/awslabs/aws-c-compression
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "aws-c-compression" %}
-{% set version = "0.2.17" %}
+{% set version = "0.2.16" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://github.com/awslabs/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: 703d1671e395ea26f8b0b70d678ed471421685a89e127f8aa125e2b2ecedb0e0
+  sha256: 044b1dbbca431a07bde8255ef9ec443c300fc60d4c9408d4b862f65e496687f4
 
 build:
-  number: 8
+  number: 0
   run_exports:
     - {{ pin_subpackage("aws-c-compression", max_pin="x.x.x") }}
 
@@ -18,9 +18,9 @@ requirements:
   build:
     - cmake
     - {{ compiler('c') }}
-    - ninja
+    - ninja-base
   host:
-    - aws-c-common
+    - aws-c-common 0.8.5
 
 test:
   commands:


### PR DESCRIPTION
aws-c-compression 0.2.16

Destination channel: defaults

Links
[{ticket_number}](https://anaconda.atlassian.net/browse/PKG-3946)
[Upstream repository](https://github.com/awslabs/aws-c-compression/releases/tag/v0.2.16)
dependency for aws-sdk-cpp 1.10.55 -> arrow-cpp 14.0.1 -> pyarrow 14.0.1 which would address CVE