### PR TITLE
aws-c-compression 0.3.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - {{ compiler('c') }}
     - ninja-base
   host:
-    - aws-c-common 0.8.5
+    - aws-c-common 0.11.1
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "aws-c-compression" %}
-{% set version = "0.2.16" %}
+{% set version = "0.3.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/awslabs/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: 044b1dbbca431a07bde8255ef9ec443c300fc60d4c9408d4b862f65e496687f4
+  sha256: d89fca17a37de762dc34f332d2da402343078da8dbd2224c46a11a88adddf754
 
 build:
   number: 0
@@ -36,7 +36,7 @@ about:
   license_file: LICENSE
   summary: C99 implementation of huffman encoding/decoding
   description: |
-    This is a cross-platform C99 implementation of compression algorithms such as gzip, and huffman 
+    This is a cross-platform C99 implementation of compression algorithms such as gzip, and huffman
     encoding/decoding. Currently only huffman is implemented.
   doc_url: https://github.com/awslabs/aws-c-compression
   dev_url: https://github.com/awslabs/aws-c-compression


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-7288](https://anaconda.atlassian.net/browse/PKG-7288)
- [Upstream repository](https://github.com/awslabs/aws-c-compression/tree/v0.3.1)

### Explanation of changes:

- Update version
- Update dependencies


[PKG-7288]: https://anaconda.atlassian.net/browse/PKG-7288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ