### PR TITLE
aws-c-compression 0.3.1 rebuild

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,17 +1,19 @@
 mkdir "%SRC_DIR%"\build
 pushd "%SRC_DIR%"\build
 
-cmake -G "Ninja" ^
+cmake -GNinja ^
       -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
       -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^
       -DCMAKE_INSTALL_LIBDIR=lib ^
       -DCMAKE_BUILD_TYPE=Release ^
       -DBUILD_SHARED_LIBS=ON ^
+      -DCMAKE_POSITION_INDEPENDENT_CODE=ON ^
+      -DENABLE_TESTING=ON ^
       ..
 if errorlevel 1 exit 1
 
-ninja install
+cmake --build . --config Release --target install
 if errorlevel 1 exit 1
 
-ninja test
+ctest --output-on-failure
 if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -10,9 +10,11 @@ cmake ${CMAKE_ARGS} -GNinja \
   -DCMAKE_INSTALL_LIBDIR=lib \
   -DCMAKE_BUILD_TYPE=Release \
   -DBUILD_SHARED_LIBS=ON \
+  -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+  -DENABLE_TESTING=ON \
   ..
-ninja install
-if [[ "${CONDA_BUILD_CROSS_COMPILATION:-0}" != "1" ]]; then
-  ninja test
-fi
+
+cmake --build . --config Release --target install
+
+ctest --output-on-failure -j${CPU_COUNT}
 popd

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: d89fca17a37de762dc34f332d2da402343078da8dbd2224c46a11a88adddf754
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage("aws-c-compression", max_pin="x.x.x") }}
 
@@ -20,7 +20,7 @@ requirements:
     - {{ compiler('c') }}
     - ninja-base
   host:
-    - aws-c-common 0.11.1
+    - aws-c-common 0.12.3
 
 test:
   commands:


### PR DESCRIPTION
aws-c-compression 0.3.1 rebuild

**Destination channel:** Defaults

### Links

- [PKG-8589]
- dev_url:        https://github.com/awslabs/aws-c-compression/tree/v0.3.1
- conda_forge:    https://github.com/conda-forge/aws-c-compression-feedstock
- pypi:           https://pypi.org/project/aws-c-compression/0.3.1
- pypi inspector: https://inspector.pypi.io/project/aws-c-compression/0.3.1/

### Explanation of changes:

- rebuild due to new dependency version


[PKG-8589]: https://anaconda.atlassian.net/browse/PKG-8589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ