### PR TITLE
aws-c-compression 0.3.1 rebuild

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,24 +10,25 @@ source:
   sha256: d89fca17a37de762dc34f332d2da402343078da8dbd2224c46a11a88adddf754
 
 build:
-  number: 1
+  number: 2
   run_exports:
     - {{ pin_subpackage("aws-c-compression", max_pin="x.x.x") }}
 
 requirements:
   build:
-    - cmake
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
+    - cmake
     - ninja-base
   host:
-    - aws-c-common 0.12.3
+    - aws-c-common 0.12.4
 
 test:
   commands:
     - test -f $PREFIX/lib/libaws-c-compression${SHLIB_EXT}  # [unix]
     - test -f $PREFIX/include/aws/compression/compression.h  # [unix]
-    - if not exist %LIBRARY_INC%\\aws\\compression\\compression.h exit 1          # [win]
-    - if not exist %PREFIX%\\Library\\bin\\aws-c-compression.dll exit 1  # [win]
+    - if not exist %LIBRARY_INC%\aws\compression\compression.h exit 1  # [win]
+    - if not exist %LIBRARY_BIN%\aws-c-compression.dll exit 1  # [win]
 
 about:
   home: https://github.com/awslabs/aws-c-compression


### PR DESCRIPTION
aws-c-compression 0.3.1 

**Destination channel:** Defaults

### Links

- [PKG-9477]
- dev_url:        https://github.com/awslabs/aws-c-compression/tree/v0.3.1
- conda_forge:    https://github.com/conda-forge/aws-c-compression-feedstock
- pypi:           https://pypi.org/project/aws-c-compression/0.3.1
- pypi inspector: https://inspector.pypi.io/project/aws-c-compression/0.3.1

### Explanation of changes:

- rebuild against aws-c-common 0.12.4


[PKG-9477]: https://anaconda.atlassian.net/browse/PKG-9477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ