### PR TITLE
Rebuild against aws-c-common 0.12.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: d89fca17a37de762dc34f332d2da402343078da8dbd2224c46a11a88adddf754
 
 build:
-  number: 2
+  number: 3
   run_exports:
     - {{ pin_subpackage("aws-c-compression", max_pin="x.x.x") }}
 
@@ -21,7 +21,7 @@ requirements:
     - cmake
     - ninja-base
   host:
-    - aws-c-common 0.12.4
+    - aws-c-common 0.12.6
 
 test:
   commands:


### PR DESCRIPTION
aws-c-compression 0.3.1

**Destination channel:** defaults

### Links

- [PKG-11744](https://anaconda.atlassian.net/browse/PKG-11744) 
- [Upstream repository](https://github.com/awslabs/aws-c-compression/tree/v0.3.1)

### Explanation of changes:

- New version number of aws-c-common


[PKG-11744]: https://anaconda.atlassian.net/browse/PKG-11744?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ