### PR TITLE
aws-c-compression 0.3.2 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "aws-c-compression" %}
-{% set version = "0.3.1" %}
+{% set version = "0.3.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://github.com/awslabs/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: d89fca17a37de762dc34f332d2da402343078da8dbd2224c46a11a88adddf754
+  sha256: f93f5a5d8b3fee3a6d97b14ba279efacd4d4016ef9cc7dc4be7d43519ecfbe93
 
 build:
-  number: 3
+  number: 0
   run_exports:
     - {{ pin_subpackage("aws-c-compression", max_pin="x.x.x") }}
 


### PR DESCRIPTION
aws-c-compression 0.3.2 

**Destination channel:** Defaults

### Links

- [PKG-13592]
- dev_url:        https://github.com/awslabs/aws-c-compression
- conda_forge:    https://github.com/conda-forge/aws-c-compression-feedstock
- pypi:           https://pypi.org/project/aws-c-compression/0.3.2
- pypi inspector: https://inspector.pypi.io/project/aws-c-compression/0.3.2

### Explanation of changes:

- new version number


[PKG-13592]: https://anaconda.atlassian.net/browse/PKG-13592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ