### PR TITLE
aws-c-compression 0.3.2 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = "0.3.2" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
@@ -10,7 +10,7 @@ source:
   sha256: f93f5a5d8b3fee3a6d97b14ba279efacd4d4016ef9cc7dc4be7d43519ecfbe93
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage("aws-c-compression", max_pin="x.x.x") }}
 
@@ -21,7 +21,7 @@ requirements:
     - cmake
     - ninja-base
   host:
-    - aws-c-common 0.12.6
+    - aws-c-common 0.14.0
 
 test:
   commands:


### PR DESCRIPTION
aws-c-compression 0.3.2 

**Destination channel:** Defaults

### Links

- [PKG-15454]
- dev_url:        https://github.com/awslabs/aws-c-compression/tree/v0.3.2
- conda_forge:    https://github.com/conda-forge/aws-c-compression-feedstock
- pypi:           None
- pypi inspector: None

### Explanation of changes:

- new **aws-c-common** version number


[PKG-15454]: https://anaconda.atlassian.net/browse/PKG-15454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ